### PR TITLE
add support for YAML anchors and aliases with corresponding tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 # ignore potential build directories
 build/
 doc/
+.qodo

--- a/example/yaml_example.F90
+++ b/example/yaml_example.F90
@@ -1,3 +1,7 @@
+!> \brief Example program demonstrating YAML parsing functionality
+!>
+!> \details This example shows how to load a YAML file and access various types of data,
+!> including nested key access and sequence handling.
 program test_fyaml
     use fyaml
     use yaml_parser, only: yaml_node
@@ -33,6 +37,7 @@ program test_fyaml
     ! Get all person keys with proper deallocation/allocation
     if (associated(person%node%children)) then
         if (allocated(keys)) deallocate(keys)
+        if (.not. allocated(keys)) allocate(character(len=32) :: keys(0))
         keys = get_keys_from_node(person%node%children)
     endif
     print *, "Keys:", keys

--- a/src/fyaml.F90
+++ b/src/fyaml.F90
@@ -1,22 +1,22 @@
-!> A modern Fortran module for parsing YAML files
-!!
-!! This module provides functionality to read and parse YAML files into Fortran
-!! data structures. It supports nested dictionaries, sequences, and various data types.
-!!
-!! Example:
-!! ```fortran
-!! type(fyaml_doc) :: doc
-!! call doc%load("config.yaml")
-!! value = doc%get("config%nested%key")
-!! ```
-!!
-!! @note Supports strings, integers, reals, booleans, nulls, and sequences
-!! @version 1.0.0
-!! @see yaml_parser
-!! @see yaml_types
+!> \brief A modern Fortran module for parsing YAML files
+!>
+!> \details This module provides functionality to read and parse YAML files into Fortran
+!> data structures. It supports nested dictionaries, sequences, and various data types.
+!>
+!> Example:
+!> \code{.f90}
+!> type(fyaml_doc) :: doc
+!> call doc%load("config.yaml")
+!> value = doc%get("config%nested%key")
+!> \endcode
+!>
+!> \note Supports strings, integers, reals, booleans, nulls, and sequences
+!> \version 1.0.0
+!> \see yaml_parser
+!> \see yaml_types
 module fyaml
-    use yaml_parser, only: yaml_node, check_sequence_node, parse_yaml, debug_print, DEBUG_INFO  ! Add DEBUG_INFO to imports
-    use yaml_types
+    use yaml_parser, only: check_sequence_node, parse_yaml, debug_print, DEBUG_INFO
+    use yaml_types, only: yaml_node, yaml_document, copy_anchor_type_to_alias
     use, intrinsic :: iso_fortran_env, only: error_unit
     implicit none
 
@@ -134,9 +134,9 @@ module fyaml
 contains
     !> Load YAML document from file
     !!
-    !! @param[in,out] this     The document instance
-    !! @param[in]     filename Path to YAML file
-    !! @param[out]    success  Optional success indicator
+    !! \param[in,out] this     The document instance
+    !! \param[in]     filename Path to YAML file
+    !! \param[out]    success  Optional success indicator
     subroutine load_yaml_doc(this, filename, success)
         class(fyaml_doc), intent(inout) :: this
         character(len=*), intent(in) :: filename
@@ -229,8 +229,8 @@ contains
 
     !> Convert a yaml_node to yaml_value
     !!
-    !! @param[in] node Source YAML node
-    !! @return Value container wrapping the node
+    !! \param[in] node Source YAML node
+    !! \return Value container wrapping the node
     function node_to_value(node) result(val)
         type(yaml_node), pointer, intent(in) :: node
         type(yaml_value) :: val
@@ -245,8 +245,8 @@ contains
 
     !> Get string value from yaml_value
     !!
-    !! @param[in] self Value container instance
-    !! @return String value or empty string if invalid
+    !! \param[in] self Value container instance
+    !! \return String value or empty string if invalid
     function get_string_value(self) result(str_val)
         class(yaml_value), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=:), allocatable :: str_val
@@ -280,8 +280,8 @@ contains
 
     !> Get integer value from yaml_value
     !!
-    !! @param[in] self Value container instance
-    !! @return Integer value or 0 if invalid
+    !! \param[in] self Value container instance
+    !! \return Integer value or 0 if invalid
     function get_integer_value(self) result(int_val)
         class(yaml_value), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         integer :: int_val
@@ -313,8 +313,8 @@ contains
 
     !> Get real value from yaml_value
     !!
-    !! @param[in] self Value container instance
-    !! @return Real value or 0.0 if invalid
+    !! \param[in] self Value container instance
+    !! \return Real value or 0.0 if invalid
     function get_real_value(self) result(real_val)
         class(yaml_value), intent(inout) :: self
         real :: real_val
@@ -327,8 +327,8 @@ contains
 
     !> Get boolean value from yaml_value
     !!
-    !! @param[in] self Value container instance
-    !! @return Boolean value or false if invalid
+    !! \param[in] self Value container instance
+    !! \return Boolean value or false if invalid
     function get_boolean_value(self) result(bool_val)
         class(yaml_value), intent(inout) :: self
         logical :: bool_val
@@ -341,19 +341,19 @@ contains
 
     !> Check if value is null
     !!
-    !! @param[in] self Value container instance
-    !! @return True if value is null
+    !! \param[in] self Value container instance
+    !! \return True if value is null
     function check_null(self) result(is_null)
         class(yaml_value), intent(in) :: self
         logical :: is_null
 
         is_null = .not. associated(self%node) .or. self%node%is_null
-    end function
+    end function check_null
 
     !> Check if value is a sequence
     !!
-    !! @param[in] self Value container instance
-    !! @return True if value is a sequence
+    !! \param[in] self Value container instance
+    !! \return True if value is a sequence
     function check_sequence_impl(self) result(is_seq)
         class(yaml_value), intent(in) :: self
         logical :: is_seq
@@ -366,8 +366,8 @@ contains
 
     !> Print yaml_node children keys
     !!
-    !! @param[in] node Node to print
-    !! @param[in] prefix Optional indentation prefix
+    !! \param[in] node Node to print
+    !! \param[in] prefix Optional indentation prefix
     subroutine print_node_children(node, prefix)
         type(yaml_node), pointer, intent(in) :: node
         character(len=*), intent(in), optional :: prefix
@@ -400,8 +400,8 @@ contains
 
     !> Convert YAML node structure to dictionary
     !!
-    !! @param[in] node Source node to convert
-    !! @param[inout] dict Target dictionary
+    !! \param[in] node Source node to convert
+    !! \param[inout] dict Target dictionary
     recursive subroutine convert_node_to_dict(node, dict)
         type(yaml_node), pointer, intent(in) :: node
         type(yaml_dict), intent(inout) :: dict
@@ -545,9 +545,9 @@ contains
 
     !> Set value for a given key in dictionary
     !!
-    !! @param[in,out] this  The dictionary instance
-    !! @param[in]     key   Key to set
-    !! @param[in]     value Value to associate with key
+    !! \param[in,out] this  The dictionary instance
+    !! \param[in]     key   Key to set
+    !! \param[in]     value Value to associate with key
     subroutine set_value(this, key, value)
         class(yaml_dict), intent(inout) :: this
         character(len=*), intent(in) :: key
@@ -578,9 +578,9 @@ contains
 
     !> Get value associated with key from dictionary
     !!
-    !! @param[in] this Dictionary instance
-    !! @param[in] key Key to lookup
-    !! @return Value associated with key
+    !! \param[in] this Dictionary instance
+    !! \param[in] key Key to lookup
+    !! \return Value associated with key
     function get_value(this, key) result(val)
         class(yaml_dict), intent(inout) :: this  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: key
@@ -646,8 +646,8 @@ contains
 
     !> Get all keys in dictionary
     !!
-    !! @param[in]  this Dictionary instance
-    !! @return     Array of all keys
+    !! \param[in]  this Dictionary instance
+    !! \return     Array of all keys
     function get_keys(this) result(keys)
         class(yaml_dict), intent(in) :: this
         character(len=:), allocatable, dimension(:) :: keys
@@ -671,9 +671,9 @@ contains
 
     !> Get nested value for yaml_value type
     !!
-    !! @param[in] self Value container instance
-    !! @param[in] key Nested key path with % delimiters
-    !! @return Value at nested path
+    !! \param[in] self Value container instance
+    !! \param[in] key Nested key path with % delimiters
+    !! \return Value at nested path
     recursive function get_value_nested(self, key) result(val)
         class(yaml_value), intent(inout) :: self
         character(len=*), intent(in) :: key
@@ -742,10 +742,10 @@ contains
 
     !> Get nested value for fyaml_doc type
     !!
-    !! @param[in] self Document instance
-    !! @param[in] path Nested path with % delimiters
-    !! @param[in] doc_index Optional document index
-    !! @return Value at nested path
+    !! \param[in] self Document instance
+    !! \param[in] path Nested path with % delimiters
+    !! \param[in] doc_index Optional document index
+    !! \return Value at nested path
     recursive function get_doc_nested(self, path, doc_index) result(val)
         class(fyaml_doc), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: path
@@ -766,10 +766,10 @@ contains
 
     !> Get nested string value
     !!
-    !! @param[in] self Document instance
-    !! @param[in] path Nested path with % delimiters
-    !! @param[in] doc_index Optional document index
-    !! @return String value at nested path
+    !! \param[in] self Document instance
+    !! \param[in] path Nested path with % delimiters
+    !! \param[in] doc_index Optional document index
+    !! \return String value at nested path
     function get_nested_str(self, path, doc_index) result(val)
         class(fyaml_doc), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: path
@@ -807,10 +807,10 @@ contains
 
     !> Get nested integer value
     !!
-    !! @param[in] self Document instance
-    !! @param[in] path Nested path with % delimiters
-    !! @param[in] doc_index Optional document index
-    !! @return Integer value at nested path
+    !! \param[in] self Document instance
+    !! \param[in] path Nested path with % delimiters
+    !! \param[in] doc_index Optional document index
+    !! \return Integer value at nested path
     function get_nested_int(self, path, doc_index) result(val)
         class(fyaml_doc), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: path
@@ -833,10 +833,10 @@ contains
 
     !> Get nested real value
     !!
-    !! @param[in] self Document instance
-    !! @param[in] path Nested path with % delimiters
-    !! @param[in] doc_index Optional document index
-    !! @return Real value at nested path
+    !! \param[in] self Document instance
+    !! \param[in] path Nested path with % delimiters
+    !! \param[in] doc_index Optional document index
+    !! \return Real value at nested path
     function get_nested_real(self, path, doc_index) result(val)
         class(fyaml_doc), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: path
@@ -854,10 +854,10 @@ contains
 
     !> Get nested boolean value
     !!
-    !! @param[in] self Document instance
-    !! @param[in] path Nested path with % delimiters
-    !! @param[in] doc_index Optional document index
-    !! @return Boolean value at nested path
+    !! \param[in] self Document instance
+    !! \param[in] path Nested path with % delimiters
+    !! \param[in] doc_index Optional document index
+    !! \return Boolean value at nested path
     function get_nested_bool(self, path, doc_index) result(val)
         class(fyaml_doc), intent(inout) :: self  ! Changed from intent(in) to intent(inout)
         character(len=*), intent(in) :: path
@@ -875,9 +875,9 @@ contains
 
     !> Get specific document by index
     !!
-    !! @param[in] this Document collection
-    !! @param[in] doc_index Index of document to get
-    !! @return Document at specified index
+    !! \param[in] this Document collection
+    !! \param[in] doc_index Index of document to get
+    !! \return Document at specified index
     function get_document(this, doc_index) result(val)
         class(fyaml_doc), intent(in) :: this
         integer, intent(in) :: doc_index
@@ -890,8 +890,8 @@ contains
 
     !> Get value from default document (first document)
     !!
-    !! @param[in] this Document collection
-    !! @return First document in collection
+    !! \param[in] this Document collection
+    !! \return First document in collection
     function get_default_doc(this) result(val)
         class(fyaml_doc), intent(in) :: this
         type(yaml_dict) :: val
@@ -903,9 +903,9 @@ contains
 
     !> Find child node by key
     !!
-    !! @param[in] node Parent node to search
-    !! @param[in] search_key Key to find
-    !! @return Value container for found child
+    !! \param[in] node Parent node to search
+    !! \param[in] search_key Key to find
+    !! \return Value container for found child
     function find_child_by_key(node, search_key) result(found_val)
         type(yaml_node), pointer, intent(in) :: node
         character(len=*), intent(in) :: search_key
@@ -937,8 +937,8 @@ contains
 
     !> Split a path by % delimiter
     !!
-    !! @param[in] path Path string to split
-    !! @return Array of path segments
+    !! \param[in] path Path string to split
+    !! \return Array of path segments
     function split_key(path) result(parts)
         character(len=*), intent(in) :: path
         character(len=:), allocatable, dimension(:) :: parts
@@ -975,7 +975,7 @@ contains
 
     !> Determine the type of a node's value
     !!
-    !! @param[inout] node Node to analyze
+    !! \param[inout] node Node to analyze
     subroutine determine_value_type(node)
         type(yaml_node), pointer, intent(inout) :: node
         integer :: int_val, ios
@@ -1034,8 +1034,8 @@ contains
 
     !> Count direct children of a yaml_node
     !!
-    !! @param[in] node Node to count children for
-    !! @return Number of direct children
+    !! \param[in] node Node to count children for
+    !! \return Number of direct children
     function count_node_children(node) result(count)
         type(yaml_node), pointer, intent(in) :: node
         integer :: count
@@ -1054,8 +1054,8 @@ contains
 
     !> Count direct children of a yaml_value
     !!
-    !! @param[in] val Value to count children for
-    !! @return Number of direct children
+    !! \param[in] val Value to count children for
+    !! \return Number of direct children
     function count_value_children(val) result(count)
         type(yaml_value), intent(in) :: val
         integer :: count
@@ -1070,8 +1070,8 @@ contains
 
     !> Get all child keys of a yaml_node
     !!
-    !! @param[in] node Node to get children from
-    !! @return Array of child key names
+    !! \param[in] node Node to get children from
+    !! \return Array of child key names
     function get_node_child_keys(node) result(keys)
         type(yaml_node), pointer, intent(in) :: node
         character(len=:), allocatable, dimension(:) :: keys
@@ -1104,8 +1104,8 @@ contains
 
     !> Get all child keys of a yaml_value
     !!
-    !! @param[in] val Value to get children from
-    !! @return Array of child key names
+    !! \param[in] val Value to get children from
+    !! \return Array of child key names
     function get_value_child_keys(val) result(keys)
         class(yaml_value), intent(in) :: val
         character(len=:), allocatable, dimension(:) :: keys
@@ -1120,9 +1120,9 @@ contains
 
     !> Get child value at specified index
     !!
-    !! @param[in] self Value container instance
-    !! @param[in] idx Index of child to retrieve (1-based)
-    !! @return Value container for child at index or null if invalid
+    !! \param[in] self Value container instance
+    !! \param[in] idx Index of child to retrieve (1-based)
+    !! \return Value container for child at index or null if invalid
     function get_child_at_index(self, idx) result(val)
         class(yaml_value), intent(in) :: self
         integer, intent(in) :: idx
@@ -1154,8 +1154,8 @@ contains
 
     !> Get sequence values as an array of strings
     !!
-    !! @param[in] self Value container instance
-    !! @return Array of sequence values as strings
+    !! \param[in] self Value container instance
+    !! \return Array of sequence values as strings
     function get_sequence_values(self) result(values)
         class(yaml_value), intent(in) :: self
         character(len=:), allocatable, dimension(:) :: values
@@ -1190,8 +1190,8 @@ contains
 
     !> Get sequence values as integers
     !!
-    !! @param[in] self Value container instance
-    !! @return Array of sequence values as integers
+    !! \param[in] self Value container instance
+    !! \return Array of sequence values as integers
     function get_sequence_integers(self) result(values)
         class(yaml_value), intent(in) :: self
         integer, allocatable, dimension(:) :: values
@@ -1227,8 +1227,8 @@ contains
 
     !> Get sequence values as reals
     !!
-    !! @param[in] self Value container instance
-    !! @return Array of sequence values as reals
+    !! \param[in] self Value container instance
+    !! \return Array of sequence values as reals
     function get_sequence_reals(self) result(values)
         class(yaml_value), intent(in) :: self
         real, allocatable, dimension(:) :: values
@@ -1264,8 +1264,8 @@ contains
 
     !> Get sequence values as logicals
     !!
-    !! @param[in] self Value container instance
-    !! @return Array of sequence values as logicals
+    !! \param[in] self Value container instance
+    !! \return Array of sequence values as logicals
     function get_sequence_bools(self) result(values)
         class(yaml_value), intent(in) :: self
         logical, allocatable, dimension(:) :: values
@@ -1300,8 +1300,8 @@ contains
 
     !> Get the size of a sequence
     !!
-    !! @param[in] self Value container instance
-    !! @return Size of sequence or 0 if not a sequence/invalid
+    !! \param[in] self Value container instance
+    !! \return Size of sequence or 0 if not a sequence/invalid
     function get_sequence_size(self) result(size)
         class(yaml_value), intent(in) :: self
         integer :: size
@@ -1316,8 +1316,8 @@ contains
 
     !> Get all root keys from the document
     !!
-    !! @param[in] this Document instance
-    !! @return Array of root key names
+    !! \param[in] this Document instance
+    !! \return Array of root key names
     function get_root_keys(this) result(keys)
         class(fyaml_doc), intent(in) :: this
         character(len=:), allocatable, dimension(:) :: keys

--- a/src/yaml_types.F90
+++ b/src/yaml_types.F90
@@ -1,15 +1,15 @@
-!> Core YAML type definitions
-!!
-!! Defines the fundamental types needed for YAML parsing.
-!! These types form the backbone of the document structure.
-!!
-!! @private
+!> \brief Core YAML type definitions
+!>
+!> \details Defines the fundamental types needed for YAML parsing.
+!> These types form the backbone of the document structure.
+!>
+!> \private
 module yaml_types
     implicit none
     private
-    public :: yaml_node, yaml_document
+    public :: yaml_node, yaml_document, copy_anchor_type_to_alias
 
-    !> Core node type for YAML elements
+    !> \brief Core node type for YAML elements
     type :: yaml_node
         character(len=:), allocatable :: key    !< Node key name
         character(len=:), allocatable :: value  !< Node value content
@@ -35,10 +35,37 @@ module yaml_types
         logical :: is_merged = .false. !< True if node is a merged reference (<<)
     end type yaml_node
 
-    !> Document container type
+    !> \brief Document container type
     type :: yaml_document
         type(yaml_node), pointer :: root => null() !< Root node
     end type yaml_document
 
     ! Remove yaml_error type - handle errors through status codes
+
+    !> \brief Interface to copy anchor node type information to alias nodes
+    interface copy_anchor_type_to_alias
+        module procedure :: copy_anchor_type_to_alias_impl
+    end interface
+
+contains
+
+    !> \brief Copy type information from an anchor node to an alias node
+    !> \param[in,out] alias_node The alias node to update
+    !> \param[in] anchor_node The anchor node to copy from
+    subroutine copy_anchor_type_to_alias_impl(alias_node, anchor_node)
+        type(yaml_node), intent(inout) :: alias_node
+        type(yaml_node), intent(in) :: anchor_node
+
+        ! Copy type flags from anchor to alias
+        alias_node%is_sequence = anchor_node%is_sequence
+        alias_node%is_null = anchor_node%is_null
+        alias_node%is_boolean = anchor_node%is_boolean
+        alias_node%is_integer = anchor_node%is_integer
+        alias_node%is_float = anchor_node%is_float
+        alias_node%is_string = anchor_node%is_string
+
+        ! Don't copy is_root - an alias can't be a root node
+        ! Don't copy is_alias/is_merged - these are properties of the alias itself
+    end subroutine copy_anchor_type_to_alias_impl
+
 end module yaml_types

--- a/src/yaml_types.F90
+++ b/src/yaml_types.F90
@@ -26,6 +26,13 @@ module yaml_types
         logical :: is_float = .false.     !< Float flag
         logical :: is_string = .true.     !< String flag (default)
         logical :: is_root = .false.      !< Root node flag (replaces is_root_key)
+
+        ! Anchor/alias support
+        character(len=:), allocatable :: anchor      !< Anchor name if node is anchored
+        character(len=:), allocatable :: alias_name  !< Name of referenced anchor if is_alias=.true.
+        type(yaml_node), pointer :: anchor_target => null() !< Points to referenced anchor node
+        logical :: is_alias = .false.  !< True if node is an alias reference
+        logical :: is_merged = .false. !< True if node is a merged reference (<<)
     end type yaml_node
 
     !> Document container type

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,11 +27,12 @@ add_executable(test_get_value test_get_value_main.F90)
 add_executable(test_get_values test_get_values_main.F90)
 add_executable(test_multiple_docs test_multiple_docs_main.F90)
 add_executable(test_root_keys test_root_keys_main.F90)
+add_executable(test_anchors_aliases test_anchors_aliases_main.F90)
 
 foreach(test IN ITEMS
     test_basic_loading test_basic_types test_sequences
     test_nested_access test_get_value test_get_values
-    test_multiple_docs test_root_keys)
+    test_multiple_docs test_root_keys test_anchors_aliases)
     # Link with test_utils and fyaml
     target_link_libraries(${test} PRIVATE test_utils)  # fyaml comes transitively
     # Set include paths for modules
@@ -49,12 +50,14 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_example.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/test_example.yaml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_example_multi_doc.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/test_example_multi_doc.yaml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_example_anchors.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/test_example_anchors.yaml COPYONLY)
 
 # Add tests
 foreach(test IN ITEMS
     basic_loading basic_types sequences
     nested_access get_value get_values
-    multiple_docs root_keys)
+    multiple_docs root_keys anchors_aliases)
     add_test(
         NAME test_${test}
         COMMAND test_${test}

--- a/tests/test_anchors_aliases_main.F90
+++ b/tests/test_anchors_aliases_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for YAML anchor and alias functionality
+!>
+!> \details Validates the proper handling of YAML anchors and aliases,
+!> ensuring that anchored values can be referenced properly.
 program test_anchors_aliases_main
     use test_utils, only: test_anchors_aliases, ERR_SUCCESS
     implicit none

--- a/tests/test_anchors_aliases_main.F90
+++ b/tests/test_anchors_aliases_main.F90
@@ -1,0 +1,7 @@
+program test_anchors_aliases_main
+    use test_utils, only: test_anchors_aliases, ERR_SUCCESS
+    implicit none
+    integer :: status
+    status = test_anchors_aliases()
+    if (status /= ERR_SUCCESS) error stop
+end program test_anchors_aliases_main

--- a/tests/test_basic_loading_main.F90
+++ b/tests/test_basic_loading_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for basic YAML file loading
+!>
+!> \details Tests the basic functionality of loading a YAML file,
+!> ensuring the parser can successfully open and read a file.
 program test_basic_loading_main
     use test_utils, only: test_basic_loading, ERR_SUCCESS
     implicit none

--- a/tests/test_basic_types_main.F90
+++ b/tests/test_basic_types_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for basic YAML data types
+!>
+!> \details Validates that the parser can correctly interpret different YAML data types
+!> including strings, integers, reals, booleans, and null values.
 program test_basic_types_main
     use test_utils, only: test_basic_types, ERR_SUCCESS
     implicit none

--- a/tests/test_example_anchors.yaml
+++ b/tests/test_example_anchors.yaml
@@ -1,9 +1,10 @@
 places:
   # TODO: doesn't work with full name "The National Center for Weather and Climate Prediction"
   - &ncwcp NCWCP
-
+  - &full_name The National Center for Weather and Climate Prediction
 barry:
   office: *ncwcp
+  full: *full_name
 
 # Base configuration with explicit values first
 defaults: &defaults
@@ -12,6 +13,9 @@ defaults: &defaults
   settings: &base_settings
     debug: true
     verbose: false
+test:
+  - test1
+  - test2
 
 # Server configurations using anchors
 server1:

--- a/tests/test_example_anchors.yaml
+++ b/tests/test_example_anchors.yaml
@@ -1,3 +1,10 @@
+places:
+  # TODO: doesn't work with full name "The National Center for Weather and Climate Prediction"
+  - &ncwcp NCWCP
+
+barry:
+  office: *ncwcp
+
 # Base configuration with explicit values first
 defaults: &defaults
   timeout: 30

--- a/tests/test_example_anchors.yaml
+++ b/tests/test_example_anchors.yaml
@@ -1,0 +1,35 @@
+# Base configuration with explicit values first
+defaults: &defaults
+  timeout: 30
+  retry: 3
+  settings: &base_settings
+    debug: true
+    verbose: false
+
+# Server configurations using anchors
+server1:
+  <<: *defaults  # Merge defaults
+  host: example.com
+  port: 8080
+  settings:
+    <<: *base_settings
+    api_key: abc123
+
+server2:
+  <<: *defaults  # Merge defaults
+  host: example.org
+  port: 9090
+  settings:
+    <<: *base_settings
+    api_key: xyz789
+
+# Colors with explicit sequence
+colors: &color_list
+  - red
+  - blue
+  - green
+
+# Theme using color list alias
+theme:
+  primary_colors: *color_list
+  secondary_colors: *color_list

--- a/tests/test_get_value_main.F90
+++ b/tests/test_get_value_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for YAML value retrieval
+!>
+!> \details Tests the ability to retrieve individual values from a YAML document
+!> using the get_value functionality.
 program test_get_value_main
   use test_utils, only: test_get_value, ERR_SUCCESS
   implicit none

--- a/tests/test_get_values_main.F90
+++ b/tests/test_get_values_main.F90
@@ -1,5 +1,8 @@
+!> \brief Test program for retrieving multiple YAML values
+!>
+!> \details Tests the ability to retrieve sequence values from a YAML document,
+!> validating that arrays of different data types can be extracted correctly.
 program test_get_values_main
-  ! use test_fyaml
   use test_utils, only: test_get_values, ERR_SUCCESS
   implicit none
   integer :: status

--- a/tests/test_multiple_docs_main.F90
+++ b/tests/test_multiple_docs_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for handling multiple YAML documents
+!>
+!> \details Tests the parsing and access of multiple YAML documents within a single file,
+!> ensuring that document boundaries are properly recognized and content is correctly organized.
 program test_multiple_docs_main
   use test_utils, only: test_multiple_docs, ERR_SUCCESS
   implicit none

--- a/tests/test_nested_access_main.F90
+++ b/tests/test_nested_access_main.F90
@@ -1,5 +1,8 @@
+!> \brief Test program for accessing nested YAML structures
+!>
+!> \details Tests the ability to navigate and retrieve values from nested YAML structures
+!> using path notation with '%' delimiters.
 program test_nested_access_main
-  ! use test_fyaml
   use test_utils, only: test_nested_access, ERR_SUCCESS
   implicit none
   integer :: status

--- a/tests/test_root_keys_main.F90
+++ b/tests/test_root_keys_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for retrieving YAML root keys
+!>
+!> \details Tests functionality to list all root-level keys in a YAML document,
+!> verifying that the top-level structure is correctly identified.
 program test_root_keys_main
     use test_utils, only: test_root_keys, ERR_SUCCESS
     implicit none

--- a/tests/test_sequences_main.F90
+++ b/tests/test_sequences_main.F90
@@ -1,3 +1,7 @@
+!> \brief Test program for YAML sequence handling
+!>
+!> \details Tests the parsing and manipulation of YAML sequences,
+!> including both flow-style and block-style sequences of various data types.
 program test_sequences_main
   ! use test_fyaml
   use test_utils, only: test_sequences, ERR_SUCCESS

--- a/tests/test_utils.F90
+++ b/tests/test_utils.F90
@@ -1294,10 +1294,18 @@ contains
             test_anchors_aliases = ERR_ASSERT
             return
         endif
-
         if (.not. val%node%is_boolean) then
             write(error_unit,*) "Expected boolean for debug setting"
             test_anchors_aliases = ERR_ASSERT
+            return
+        endif
+        call assert_equal( &
+            .true., &
+            val%get_bool(), &
+            "Debug setting should be true", &
+            status)
+        if (status /= ERR_SUCCESS) then
+            test_anchors_aliases = status
             return
         endif
 

--- a/tests/test_utils.F90
+++ b/tests/test_utils.F90
@@ -1260,7 +1260,7 @@ contains
         character(len=:), allocatable :: str_val
         integer :: int_val, status
         logical :: success
-        character(len=:), allocatable, dimension(:) :: color_list
+        character(len=:), allocatable, dimension(:) :: color_list, seq_val
 
         test_anchors_aliases = ERR_SUCCESS
 
@@ -1300,6 +1300,45 @@ contains
             test_anchors_aliases = ERR_ASSERT
             return
         endif
+
+        ! Test a simple anchor case with string value
+        val = doc%get("places")
+        if (.not. associated(val%node)) then
+            write(error_unit,*) "Failed to get places node"
+            test_anchors_aliases = ERR_ASSERT
+            return
+        endif
+        if (.not. val%is_sequence()) then
+            write(error_unit,*) "Expected sequence for places"
+            test_anchors_aliases = ERR_ASSERT
+            return
+        endif
+        seq_val = val%get_sequence()
+        call assert_equal( &
+            "NCWCP", &
+            seq_val(1), &
+            "First place", &
+            status)
+        if (status /= ERR_SUCCESS) then
+            test_anchors_aliases = status
+            return
+        endif
+        val = doc%get("barry%office")
+        if (.not. associated(val%node)) then
+            write(error_unit,*) "Failed to get barry%office node"
+            test_anchors_aliases = ERR_ASSERT
+            return
+        endif
+        ! str_val = val%get_str()
+        ! call assert_equal( &
+        !     "NCWCP", &
+        !     str_val, &
+        !     "Barry's office", &
+        !     status)
+        ! if (status /= ERR_SUCCESS) then
+        !     test_anchors_aliases = status
+        !     return
+        ! endif
 
         ! ! Test sequence aliases
         ! val = doc%get("colors")

--- a/tests/test_utils.F90
+++ b/tests/test_utils.F90
@@ -34,6 +34,7 @@ module test_utils
     ! Test files
     character(len=*), parameter :: TEST_FILE = SOURCE_DIR//"/test_example.yaml"
     character(len=*), parameter :: TEST_MULTI_DOC_FILE = SOURCE_DIR//"/test_example_multi_doc.yaml"
+    character(len=*), parameter :: TEST_ANCHORS_FILE = SOURCE_DIR//"/test_example_anchors.yaml"
 
     ! Remove duplicate test data - consolidate into single section
     ! Test data parameters
@@ -1264,7 +1265,7 @@ contains
         test_anchors_aliases = ERR_SUCCESS
 
         ! Load test file with anchors - use correct path without "tests/" prefix
-        call doc%load("test_example_anchors.yaml", success)
+        call doc%load(TEST_ANCHORS_FILE, success)
         if (.not. success) then
             write(error_unit,*) "Failed to load YAML file"
             test_anchors_aliases = ERR_ALLOC


### PR DESCRIPTION
This pull request includes significant updates to the YAML parser, focusing on enhancing anchor and alias handling, improving documentation, and adding new tests. The most important changes are detailed below:

### Enhancements to YAML Parser:

* Added functions for processing anchors and aliases, including `process_anchor_alias`, `find_anchor_node`, and `resolve_aliases`, which improve the handling of YAML anchor and alias references. (`src/yaml_parser.F90`) [[1]](diffhunk://#diff-416cede97bc7beda8d70664a70d7ea774efbb2c20febed7963c15771091ac218R53-R56) [[2]](diffhunk://#diff-416cede97bc7beda8d70664a70d7ea774efbb2c20febed7963c15771091ac218R402-R410) [[3]](diffhunk://#diff-416cede97bc7beda8d70664a70d7ea774efbb2c20febed7963c15771091ac218R514-R516) [[4]](diffhunk://#diff-416cede97bc7beda8d70664a70d7ea774efbb2c20febed7963c15771091ac218R1077-R1100) [[5]](diffhunk://#diff-416cede97bc7beda8d70664a70d7ea774efbb2c20febed7963c15771091ac218R1994-R2161)
* Introduced new fields in the `yaml_node` type to support anchors and aliases, such as `anchor`, `alias_name`, `anchor_target`, `is_alias`, and `is_merged`. (`src/yaml_types.F90`)

### Documentation Updates:

* Updated the `README.md` to include more detailed explanations and examples, such as basic loading, nested access, and working with sequences and multiple documents. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46-R47) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L142-R144) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R157-R245)

### New Tests:

* Added a new test program `test_anchors_aliases_main.F90` to verify the functionality of anchors and aliases in YAML documents. (`tests/test_anchors_aliases_main.F90`)
* Created a new YAML test file `test_example_anchors.yaml` to provide test cases for the newly added anchor and alias features. (`tests/test_example_anchors.yaml`)

### Build and Test Configuration:

* Updated `CMakeLists.txt` to include the new test executable `test_anchors_aliases` and corresponding test YAML file. (`tests/CMakeLists.txt`) [[1]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR30-R35) [[2]](diffhunk://#diff-4461c617ceae0c7e0206622aacdf555aedd62eb129c2efb74c84fa1567bcbe0dR53-R60)

### Test Utilities:

* Extended the `test_utils` module to include the new `test_anchors_aliases` function and the `is_bool` public variable. (`tests/test_utils.F90`) [[1]](diffhunk://#diff-bf65186b6c6100df81707695c39d046c0d46edc4111f36190fa0e4ff0f7aa0beL7-R7) [[2]](diffhunk://#diff-bf65186b6c6100df81707695c39d046c0d46edc4111f36190fa0e4ff0f7aa0beR22-R24)