### PR TITLE
Enhance GitHub Actions workflow: add error handling for PR comments

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -146,23 +146,33 @@ jobs:
     - name: Comment on PR
       if: success() && github.event.number
       uses: actions/github-script@v7
+      continue-on-error: true  # Don't fail the workflow if commenting fails
       with:
         script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '✅ Documentation builds successfully! Preview will be available once merged to main.'
-          })
+          try {
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ Documentation builds successfully! Preview will be available once merged to main.'
+            });
+          } catch (error) {
+            console.log('Could not create comment:', error.message);
+          }
 
     - name: Comment on PR failure
       if: failure() && github.event.number
       uses: actions/github-script@v7
+      continue-on-error: true  # Don't fail the workflow if commenting fails
       with:
         script: |
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: '❌ Documentation build failed. Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
-          })
+          try {
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '❌ Documentation build failed. Please check the [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            });
+          } catch (error) {
+            console.log('Could not create comment:', error.message);
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,23 @@
 
 # ignore potential build directories
 build/
+build-fix/
 doc/
+site/
 .qodo
+
+# MkDocs and documentation generation
+.mkdoxy/
+**/doxygen_*
+**/xml/
+
+# Python build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+_version.py
 
 # documentation
 *.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # FYAML - Fortran YAML Parser
 
-FYAML is a modern Fortran library designed to parse YAML (YAML Ain't Markup Language) files with full support for advanced features including:
+FYAML is a modern Fortran library designed to parse YAML (Yet Another Markup Language) files with full support for advanced features including:
 
 - **Complete YAML syntax support** - handles mappings, sequences, scalars
 - **Anchor and alias support** - full implementation of YAML merge keys (`<<: *anchor`)


### PR DESCRIPTION
This pull request includes improvements to error handling in GitHub Actions workflows and a correction to the documentation for the FYAML project. Below are the key changes:

### Workflow Improvements:
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR149-R178): Added `continue-on-error: true` to prevent workflow failures when PR comments cannot be created. Wrapped the `github.rest.issues.createComment` calls in `try-catch` blocks to log errors instead of failing the workflow.

### Documentation Correction:
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L3-R3): Updated the YAML acronym in the description from "YAML Ain't Markup Language" to "Yet Another Markup Language" for accuracy.